### PR TITLE
launch.py fullpath doesn't use realpath

### DIFF
--- a/flyrpc/launch.py
+++ b/flyrpc/launch.py
@@ -8,14 +8,11 @@ from flyrpc.util import find_free_port
 
 def fullpath(file):
     """
-    NOTE: if you are getting here because of an import error 
-    you may be using a virtual environment with symlinks.
-
-    make a new env with 
-
-    `python3 -m venv --copies <name_of_ur_venv>`
+    Instead of undoing the symlinks and getting to the "real path",
+    maintain symlinks. This avoids the problem caused when using
+    virtual environments with symlinks to the python executable.
     """
-    return os.path.realpath(os.path.expanduser(file))
+    return os.path.expanduser(file)
 
 def launch_server(module_or_filename, new_env_vars=None, server_poll_timeout=10, server_poll_interval=0.1, **kwargs):
     # create list to hold command


### PR DESCRIPTION
This fixes the bug in which using Python venvs leads to the children processes being unable to find flystim.